### PR TITLE
docs: correct typo in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     The <b>Secure</b> Microsoft Windows Downloader
 </p>
 
-Mido is a secure and open source download client for Microsoft's (reverse engineered) proprietary downloading API! Downloads are sourced from **official** Microsoft servers and you only have to run one command to from go start to finish in no time!
+Mido is a secure and open source download client for Microsoft's (reverse engineered) proprietary downloading API! Downloads are sourced from **official** Microsoft servers and you only have to run one command to go from start to finish in no time!
 
 Comes with advanced features like download resumption, SHA-256 checksum verification, and downloading many different Windows versions in a single command. Did I mention it's written in *pure* POSIX sh (w/ few coreutils) + curl so it will run anywhere (even on Windows with WSL or a Cygwin shell)? So robust, very minimalist!
 


### PR DESCRIPTION
Changed this sentence - "Downloads are sourced from official Microsoft servers and you only have to run one command to **from go** start to finish in no time!" to this "Downloads are sourced from official Microsoft servers and you only have to run one command to **go from** start to finish in no time!"